### PR TITLE
audit: initialize state fields and fix clarification tracking

### DIFF
--- a/audit/SKILL.md
+++ b/audit/SKILL.md
@@ -117,7 +117,9 @@ cat > .audit-loop/state.json << 'STATEEOF'
   "revision_round": 0,
   "batches_created": 0,
   "last_trigger": "audit-start",
-  "last_trigger_time": "ISO8601_NOW"
+  "last_trigger_time": "ISO8601_NOW",
+  "awaiting_clarification": false,
+  "revision_history": []
 }
 STATEEOF
 ```
@@ -193,19 +195,28 @@ When a message arrives, first run the timeout check (see above). Then act based 
 
 Update state.json: set `phase` to `reviewing`, `current_pr` to N, update `last_trigger_time`.
 
-1. **Check for clarification requests** from the address agent before reviewing:
+1. **Check for pending clarification** using the state file, not comment history:
+   
+   Read `awaiting_clarification` from `.audit-loop/state.json`. If `false`, skip to step 2.
+   
+   If `true`, the address agent is blocked on a clarification. Find the unanswered question:
    ```bash
-   gh pr view N --json comments --jq '.comments[] | select(.body | startswith("Clarification needed:")) | .body'
+   gh pr view N --json comments --jq '[.comments[] | select(.body | startswith("Clarification needed:"))] | last | .body'
    ```
-   If a clarification comment exists without a follow-up response, answer it directly based on your original review intent:
+   Answer it directly based on your original review intent:
    ```bash
-   gh pr comment N --body "<answer the clarification>"
+   gh pr comment N --body "$(cat <<'EOF'
+   <answer the clarification>
+   EOF
+   )"
    ```
    Then, **in this order** (the address agent reads state.json immediately on trigger):
    1. Set `awaiting_clarification` to `false` in state.json
    2. Send `ADDRESS: revise PR #N` via tmux
 
    Do not proceed with the diff review — the address agent will revise first.
+   
+   **Important:** Do NOT search for clarification comments when `awaiting_clarification` is `false`. Historical clarification comments that have already been answered must be ignored — the state flag is the source of truth, not the comment history.
 
 2. Read the PR:
    ```bash


### PR DESCRIPTION
## Audit Fixes (Batch 2)

<!-- audit-revision: 0 -->

Addresses:
- #2: Initialize all required state keys in .audit-loop/state.json
- #3: Answered clarification comments still look pending to the audit agent

## Root Cause Analysis

**Issue #2 — Root cause:** The audit skill's initial state template omits `awaiting_clarification` and `revision_history`, but both skills branch on these fields during timeout checks and convergence detection. Missing keys cause undefined behavior on first use.
**Fix:** Add both fields to the initial state template in audit/SKILL.md Step 2.
**Risk:** None — additive, existing state files unaffected.

**Issue #3 — Root cause:** The audit agent's clarification check searches for any comment starting with "Clarification needed:" — this matches historical comments that have already been answered. Once a clarification has ever existed on a PR, every subsequent review trigger rediscovers the old comment and short-circuits into another revision instead of reviewing the diff, creating an infinite loop.
**Fix:** Replace comment-body matching with a state.json-based check: read `awaiting_clarification` flag. If true, find and answer the latest clarification. If false, skip — the state flag is the source of truth, not comment history.
**Risk:** If address agent crashes after setting the flag but before writing the comment, audit agent sees true but finds no comment. Mitigated by only searching comments when flag is true.

## Changes

- **audit/SKILL.md Step 2 (line 117-122):** Added `"awaiting_clarification": false` and `"revision_history": []` to initial state template
- **audit/SKILL.md Step 5 clarification check (line 195-220):** Replaced comment-body-based search with state.json flag check. Only searches comments when `awaiting_clarification` is true. Added explicit rule that historical comments must be ignored when flag is false. Also applied heredoc pattern to clarification answer comment.

## Test plan
- Verify initial state template includes all fields both skills reference
- Verify clarification flow: when `awaiting_clarification` is false, the audit agent skips straight to diff review even if old "Clarification needed:" comments exist
- Verify clarification flow: when `awaiting_clarification` is true, the audit agent finds and answers the latest comment, clears the flag, and triggers revision