### PR TITLE
audit: fix convergence detection and unify issue references

### DIFF
--- a/address/SKILL.md
+++ b/address/SKILL.md
@@ -233,9 +233,11 @@ Update state.json: set `last_trigger` to `ADDRESS: continue`, `revision_round` t
    ```
    Then retry merge. If still failing, label `needs-human` and move on.
 
-2. Close the issues fixed by this PR (if using `Closes #N` in commit, they auto-close on merge — verify):
+2. Explicitly close the issues listed in the PR body (do not rely on auto-close from commit messages — squash merges may not propagate closing keywords):
    ```bash
-   gh issue close <number> --reason completed
+   for issue in $(gh pr view <number> --json body -q '.body' | grep -oiE 'closes?\s+#[0-9]+' | grep -oE '[0-9]+'); do
+     gh issue close "$issue" --reason completed
+   done
    ```
 
 3. Check the batch cap — read `batches_created` from state.json. If >= 5, signal completion.
@@ -478,9 +480,8 @@ Update state.json: set `last_trigger` to `ADDRESS: revise PR #N`, update `last_t
 
    <!-- audit-revision: 0 -->
 
-   Addresses:
-   - #<issue1>: <title>
-   - #<issue2>: <title>
+   Closes #<issue1>: <title>
+   Closes #<issue2>: <title>
 
    ## Root Cause Analysis
    <copy the hypotheses from .audit-loop/batch-N-hypotheses.md here — root cause, fix, risk for each issue>

--- a/audit/SKILL.md
+++ b/audit/SKILL.md
@@ -273,11 +273,12 @@ tmux send-keys -t address Enter
 
    Read `revision_round` from state.json. Do NOT increment it — the address agent owns that counter and increments on push.
 
-   **Convergence check (after 2nd revision, before requesting the 3rd):** If `revision_round` >= 2, check for convergence before requesting another round. Read `revision_history` from state.json and get the previous revision's commit SHA. Compare:
+   **Convergence check (after 2nd revision, before requesting the 3rd):** If `revision_round` >= 2, check for convergence before requesting another round. Read `revision_history` from state.json and get the previous revision's commit SHA. Compare using the PR tip commit (not local `HEAD`, which may not be the PR branch):
    ```bash
    base=$(gh pr view N --json commits --jq '.commits[0].oid')
+   tip=$(gh pr view N --json commits --jq '.commits[-1].oid')
    prev_commit=<from revision_history[-1].commit>
-   curr_diff=$(git diff $prev_commit..HEAD | wc -l)
+   curr_diff=$(git diff $prev_commit..$tip | wc -l)
    prev_diff=$(git diff $base..$prev_commit | wc -l)
    ```
    If `curr_diff` < 30% of `prev_diff`, the revisions are cancelling each other out. Do NOT request another revision:


### PR DESCRIPTION
## Audit Fixes (Batch 3)

<!-- audit-revision: 0 -->

Closes #4: Convergence detection diffs against local HEAD instead of the PR tip
Closes #5: Issue verification and closure use a different issue-reference format than the PR template

## Root Cause Analysis

**Issue #4 — Root cause:** The convergence check uses `git diff $prev_commit..HEAD` where `HEAD` is whatever the audit agent has checked out locally, not the PR's latest commit. The audit flow never checks out the PR branch before running this diff, so the anti-thrashing guard can make wrong decisions in either direction.
**Fix:** Replace `HEAD` with `$tip` fetched via `gh pr view N --json commits --jq '.commits[-1].oid'`.
**Risk:** Minimal — same API call pattern already used for the base commit.

**Issue #5 — Root cause:** The PR body template uses `Addresses: - #N` but the audit agent's fix-verified grep parses `closes?\s+#[0-9]+` from the PR body. The `Closes #N` keywords only appeared in the commit message. With squash merge, auto-close from commit messages is unreliable.
**Fix:** Changed PR body template to use `Closes #N: <title>` format. Updated the address agent's merge flow to explicitly parse and close issues from the PR body using the same regex the audit agent uses, instead of relying on auto-close.
**Risk:** Cosmetic format change. Explicit closure is more reliable than auto-close.

## Changes

- **audit/SKILL.md convergence check (line 276-282):** Added `tip=$(gh pr view N --json commits --jq '.commits[-1].oid')`, replaced `HEAD` with `$tip` in the diff
- **address/SKILL.md PR body template (line 480-483):** Changed `Addresses: - #N: <title>` to `Closes #N: <title>`
- **address/SKILL.md merge/close flow (line 236-239):** Replaced single `gh issue close` with a loop that parses issue numbers from the PR body using `grep -oiE 'closes?\s+#[0-9]+'` — same regex the audit agent uses for fix-verified

## Test plan
- Verify convergence check uses PR tip SHA, not local HEAD
- Verify PR body `Closes #N` format is parseable by both the audit agent's fix-verified grep and the address agent's close loop
- Verify the close loop handles multiple issues in a single PR body