### PR TITLE
audit: harden audit review jq flows

### DIFF
--- a/audit/SKILL.md
+++ b/audit/SKILL.md
@@ -328,9 +328,10 @@ Update state.json: set `phase` to `reviewing`, `current_pr` to N, update `last_t
    
    If `true`, the address agent is blocked on a clarification. Find the unanswered question:
    ```bash
-   gh pr view N --json comments --jq '[.comments[] | select(.body | startswith("Clarification needed:"))] | last | .body'
+   gh pr view N --json comments \
+     --jq '[.comments[] | select(.body | startswith("Clarification needed:"))] | if length > 0 then last.body else empty end'
    ```
-   Answer it directly based on your original review intent:
+   If the command prints a clarification comment, answer it directly based on your original review intent:
    ```bash
    gh pr comment N --body "$(cat <<'EOF'
    <answer the clarification>
@@ -342,6 +343,8 @@ Update state.json: set `phase` to `reviewing`, `current_pr` to N, update `last_t
    2. Send `ADDRESS: revise PR #N` via tmux
 
    Do not proceed with the diff review — the address agent will revise first.
+
+   If the command prints nothing, the state flag is stale or the clarification comment was removed. Clear `awaiting_clarification` in state.json and continue with step 2 instead of looking for a ghost comment.
    
    **Important:** Do NOT search for clarification comments when `awaiting_clarification` is `false`. Historical clarification comments that have already been answered must be ignored — the state flag is the source of truth, not the comment history.
 
@@ -405,7 +408,7 @@ tmux send-keys -t address Enter
    git fetch origin
    base=$(gh pr view N --json commits --jq '.commits[0].oid')
    tip=$(gh pr view N --json commits --jq '.commits[-1].oid')
-   prev_commit=<from revision_history[-1].commit>
+   prev_commit=$(jq -r '.revision_history[-1].commit // empty' .audit-loop/state.json)
    if [ -z "$base" ] || [ -z "$tip" ] || [ -z "$prev_commit" ]; then
      echo "WARNING: Could not resolve commit SHAs for convergence check — skipping"
    else
@@ -481,7 +484,7 @@ Proceed to Step 6.
 1. **Check for critiqued issues.** The address agent may have removed the `audit-loop` label from issues that were unclear or invalid. Find them:
    ```bash
    gh issue list --state open --json number,title,body,comments,labels --limit 100 \
-     --jq '[.[] | select(.comments[-1].body | startswith("Issue needs clarification"))]'
+     --jq '[.[] | select((.comments | length) > 0 and any(.comments[]; .body | startswith("Issue needs clarification")))]'
    ```
    For each critiqued issue:
    - Read the address agent's comment to understand what's unclear


### PR DESCRIPTION
## Audit Fixes (Batch 1)

<!-- audit-revision: 0 -->

Closes #21: Final sweep jq crashes on issues with no comments
Closes #22: Final sweep only checks last comment — misses critiqued issues
Closes #23: Convergence check has non-executable pseudo-code for prev_commit
Closes #26: Clarification search jq crashes when no matching comments exist

## Root Cause Analysis
Issue #21
- Root cause: The final sweep dereferences `.comments[-1].body` without first proving a comment exists, so jq aborts on open issues with zero comments.
- Fix: Guard the comments array before reading the last comment body.
- Risk: A too-narrow guard could stop the crash but still miss valid critiqued issues.

Issue #22
- Root cause: The final sweep assumes the critique is always the last comment, which stops being true as soon as the audit agent or a human replies.
- Fix: Search the full comment history with `any(...)` for the clarification prefix instead of checking only the last comment.
- Risk: A broad history search could re-surface already handled issues if the clarification prefix is not specific enough.

Issue #23
- Root cause: The convergence-check instructions include non-executable pseudo-code for `prev_commit`, so a literal implementation cannot resolve the prior revision SHA.
- Fix: Replace the placeholder with a concrete `jq -r '.revision_history[-1].commit // empty'` extraction from `.audit-loop/state.json`.
- Risk: Using the wrong revision-history entry would compare the wrong commits and misfire the convergence guard.

Issue #26
- Root cause: The clarification lookup assumes a matching comment always exists and unconditionally applies `last | .body`, which crashes when the filtered list is empty.
- Fix: Guard the filtered clarification-comment array and tell the audit agent to clear `awaiting_clarification` and resume the normal review flow when no matching comment exists.
- Risk: If the clarification prefix changes later, the fallback could clear the flag without locating a legitimate unanswered question.

## Changes
- Hardened the pending-clarification query so missing matching comments no longer crash the jq pipeline.
- Documented the stale-clarification fallback so the audit agent clears the flag and continues reviewing instead of stalling.
- Replaced the convergence-check pseudo-code with a concrete `jq` extraction for `prev_commit`.
- Updated the final sweep to guard empty comment arrays and search all comments for clarification critiques.

## Test plan
- Verified by inspection that the updated clarification query now returns empty output instead of a jq type error when no matching comment exists.
- Verified by inspection that the final-sweep query now handles zero-comment issues and still finds issues whose clarification comment is no longer last.
- No project linter, formatter, or automated test suite is configured in this repository.