### PR TITLE
audit: harden address review parsing

### DIFF
--- a/address/SKILL.md
+++ b/address/SKILL.md
@@ -336,9 +336,11 @@ Update state.json: set `last_trigger` to `ADDRESS: revise PR #N`, update `last_t
 
 2. Read review comments:
    ```bash
-   gh pr view N --json reviews --jq '.reviews[-1].body'
-   gh api repos/{owner}/{repo}/pulls/N/comments --jq '.[] | select(.pull_request_review_id) | {path, body, line}'
+   review_body=$(gh pr view N --json reviews --jq '(.reviews[-1].body // empty)')
+   repo=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
+   gh api "repos/$repo/pulls/N/comments" --jq '.[] | select(.pull_request_review_id) | {path, body, line}'
    ```
+   If `review_body` is empty, the audit review has not been posted yet (or was deleted). Re-send `AUDIT: review PR #N`, do not check out the branch, and wait for the next trigger instead of parsing empty feedback.
 
 3. Check out the PR branch:
    ```bash


### PR DESCRIPTION
## Audit Fixes (Batch 2)

<!-- audit-revision: 0 -->

Closes #24: Revision handler crashes on PRs with zero reviews
Closes #25: gh api call uses literal {owner}/{repo} placeholder

## Root Cause Analysis
Issue #24
- Root cause: The revision handler assumes `gh pr view ... .reviews[-1].body` always returns a body, so it crashes or proceeds with empty feedback when a review is missing.
- Fix: Guard the jq lookup with `// empty` and explicitly re-trigger the audit review flow when no review body is available yet.
- Risk: If the fallback only checks the top-level review body, it could still miss actionable inline-only feedback.

Issue #25
- Root cause: The inline review comment fetch uses a literal `{owner}/{repo}` placeholder, so the documented command cannot ever resolve the PR comments endpoint.
- Fix: Replace the placeholder with a concrete `gh repo view --json nameWithOwner -q '.nameWithOwner'` expansion and keep the `gh api` query scoped to review comments.
- Risk: If the endpoint string is still malformed, the revision handler will keep dropping inline feedback and force unnecessary revision rounds.

## Changes
- Hardened the top-level review-body lookup so missing reviews degrade to empty output instead of a jq type error.
- Added an explicit retry path instructing the address agent to re-send `AUDIT: review PR #N` and stop when the review body is still unavailable.
- Replaced the literal `{owner}/{repo}` placeholder with a concrete repository lookup for the inline review comments API call.

## Test plan
- Verified by inspection that the new review-body command returns empty output instead of crashing when `.reviews[-1]` is null.
- Verified by inspection that the documented `gh api` path now expands against the real repository name rather than a literal placeholder.
- No project linter, formatter, or automated test suite is configured in this repository.